### PR TITLE
Change default system console to tty1

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,7 +56,7 @@ const (
 	fi                                                                              
 	menuentry "%s" --class os --unrestricted {                                     
 		echo Loading kernel...                                                      
-		$linux ($root)/boot/kernel cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs rd.live.overlay.overlayfs console=tty1 console=ttyS0 rd.cos.disable
+		$linux ($root)/boot/kernel cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs rd.live.overlay.overlayfs console=ttyS0 console=tty1 rd.cos.disable
 		echo Loading initrd...                                                      
 		$initrd ($root)/boot/initrd                                                 
 	}                                                                               


### PR DESCRIPTION
because when 2 are defined, it seems that the last one becomes the "default", at least as far as systemd is concerned.

This should allow us to read the kairos logs using journalctl.

See more here: https://github.com/kairos-io/packages/pull/544