### PR TITLE
Add nodepair.enable to the default cmdline

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,7 +42,7 @@ const (
 	Archx86   = "x86_64"
 	ArchArm64 = "arm64"
 
-	UkiCmdline = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
+	UkiCmdline = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 nodepair.enable"
 )
 
 // GetDefaultSquashfsOptions returns the default options to use when creating a squashfs


### PR DESCRIPTION
That value makes the installer run automatically when running of a media (CD/USB?PXE?) so it has the same behaviour as normal Kairos

Does not affect any other booting, it needs to be in install mode (running of an installer media)