### PR TITLE
Generate multiple efi files based on cmdlines

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -77,7 +77,7 @@ func NewBuildUKICmd() *cobra.Command {
 	}
 
 	c.Flags().StringP("output", "o", "output.uki.iso", "Output file name")
-	c.Flags().StringP("cmdline", "c", "", "Kernel command line")
+	c.Flags().StringSliceP("cmdline", "c", []string{}, "Command line to ")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
 	c.MarkFlagRequired("keys")
 	return c

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -369,13 +369,15 @@ func (b *BuildUKIAction) createConfFiles(sourceDir, cmdline string) error {
 	extraCmdline := strings.TrimPrefix(cmdline, constants.UkiCmdline)
 	// Add some  ( ) around the extra cmdline if it's not empty for a nicer display
 	if extraCmdline != "" {
-		cmdlineForConf = fmt.Sprintf("(%s)", extraCmdline)
+		cmdlineForConf = fmt.Sprintf("(%s)", strings.Trim(extraCmdline, " "))
 	} else {
 		// Empty extra cmdline, we don't want to display anything
 		cmdlineForConf = extraCmdline
 	}
 	b.logger.Infof("Creating the %s.conf file", finalEfiName)
-	data := fmt.Sprintf("title Kairos %s %s\nefi /EFI/kairos/%s.efi\nversion %s", kairosVersion, cmdlineForConf, finalEfiName, kairosVersion)
+	// You can add entries into the config files, they will be ignored by systemd-boot
+	// So we store the cmdline in a key cmdline for easy tracking of what was added to the uki cmdline
+	data := fmt.Sprintf("title Kairos %s %s\nefi /EFI/kairos/%s.efi\nversion %s\ncmdline %s", kairosVersion, cmdlineForConf, finalEfiName, kairosVersion, strings.Trim(extraCmdline, " "))
 	err = os.WriteFile(filepath.Join(sourceDir, finalEfiName+".conf"), []byte(data), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("creating the %s.conf file", finalEfiName)

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -3,6 +3,7 @@ package action
 import (
 	"compress/gzip"
 	"fmt"
+	"github.com/kairos-io/enki/pkg/constants"
 	"io"
 	"math"
 	"os"
@@ -65,18 +66,20 @@ func (b *BuildUKIAction) Run() error {
 		return err
 	}
 
-	b.logger.Info("running ukify")
-	if err := b.ukify(sourceDir); err != nil {
-		return err
+	cmdlines := utils.GetUkiCmdline()
+	for _, cmdline := range cmdlines {
+		b.logger.Info("running ukify for cmdline: " + cmdline)
+		if err := b.ukify(sourceDir, cmdline); err != nil {
+			return err
+		}
+		b.logger.Info("creating kairos and loader conf files")
+		if err := b.createConfFiles(sourceDir, cmdline); err != nil {
+			return err
+		}
 	}
 
-	b.logger.Info("running sgsign")
+	b.logger.Info("running sbsign")
 	if err := b.sbSign(sourceDir); err != nil {
-		return err
-	}
-
-	b.logger.Info("creating kairos and loader conf files")
-	if err := b.createConfFiles(sourceDir); err != nil {
 		return err
 	}
 
@@ -84,7 +87,7 @@ func (b *BuildUKIAction) Run() error {
 		return err
 	}
 
-	b.logger.Info(fmt.Sprintf("Done buidling the iso file: %s", b.isoFile))
+	b.logger.Info(fmt.Sprintf("Done building the iso file: %s", b.isoFile))
 
 	return nil
 }
@@ -291,7 +294,7 @@ func (b *BuildUKIAction) copyKernel(sourceDir string) error {
 	return err
 }
 
-func (b *BuildUKIAction) ukify(sourceDir string) error {
+func (b *BuildUKIAction) ukify(sourceDir, cmdline string) error {
 	// Normally that's still the current dir but just making sure.
 	if err := os.Chdir(sourceDir); err != nil {
 		return fmt.Errorf("changing to %s directory: %w", sourceDir, err)
@@ -311,10 +314,15 @@ func (b *BuildUKIAction) ukify(sourceDir string) error {
 		return err
 	}
 
+	// name: kairosVersion + cmdline + .efi
+	// for the cmdline, we remove the shared cmdline avalues and only keep the extra values added by the user
+	// we also replace spaces with underscores
+	finalEfiName := kairosVersion + strings.Replace(strings.TrimPrefix(cmdline, constants.UkiCmdline), " ", "_", -1) + ".efi"
+	b.logger.Infof("Generating: " + finalEfiName)
 	cmd := exec.Command("/usr/lib/systemd/ukify",
 		"--linux", "vmlinuz",
 		"--initrd", "initrd",
-		"--cmdline", utils.GetUkiCmdline(),
+		"--cmdline", cmdline,
 		"--os-release", fmt.Sprintf("@%s", "etc/os-release"),
 		"--uname", uname,
 		"--stub", "/usr/lib/systemd/boot/efi/linuxx64.efi.stub",
@@ -322,7 +330,7 @@ func (b *BuildUKIAction) ukify(sourceDir string) error {
 		"--secureboot-certificate", filepath.Join(b.keysDirectory, "DB.pem"),
 		"--pcr-private-key", filepath.Join(b.keysDirectory, "tpm2-pcr-private.pem"),
 		"--measure",
-		"--output", filepath.Join(sourceDir, kairosVersion+".efi"),
+		"--output", finalEfiName,
 		"build",
 	)
 
@@ -350,15 +358,27 @@ func (b *BuildUKIAction) sbSign(sourceDir string) error {
 	return nil
 }
 
-func (b *BuildUKIAction) createConfFiles(sourceDir string) error {
+func (b *BuildUKIAction) createConfFiles(sourceDir, cmdline string) error {
+	var cmdlineForConf string
 	kairosVersion, err := findKairosVersion(sourceDir)
 	if err != nil {
 		return err
 	}
-	data := fmt.Sprintf("title Kairos %[1]s\nefi /EFI/kairos/%[1]s.efi\nversion %[1]s", kairosVersion)
-	err = os.WriteFile(filepath.Join(sourceDir, kairosVersion+".conf"), []byte(data), os.ModePerm)
+	finalEfiName := kairosVersion + strings.Replace(strings.TrimPrefix(cmdline, constants.UkiCmdline), " ", "_", -1)
+	// For the config title we get only the extra cmdline we added, no replacement of spaces with underscores needed
+	extraCmdline := strings.TrimPrefix(cmdline, constants.UkiCmdline)
+	// Add some  ( ) around the extra cmdline if it's not empty for a nicer display
+	if extraCmdline != "" {
+		cmdlineForConf = fmt.Sprintf("(%s)", extraCmdline)
+	} else {
+		// Empty extra cmdline, we don't want to display anything
+		cmdlineForConf = extraCmdline
+	}
+	b.logger.Infof("Creating the %s.conf file", finalEfiName)
+	data := fmt.Sprintf("title Kairos %s %s\nefi /EFI/kairos/%s.efi\nversion %s", kairosVersion, cmdlineForConf, finalEfiName, kairosVersion)
+	err = os.WriteFile(filepath.Join(sourceDir, finalEfiName+".conf"), []byte(data), os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("creating the %s.conf file", kairosVersion)
+		return fmt.Errorf("creating the %s.conf file", finalEfiName)
 	}
 
 	data = "default @saved\ntimeout 5\nconsole-mode max\neditor no\n"
@@ -429,13 +449,13 @@ func (b *BuildUKIAction) imageFiles(sourceDir string) (map[string][]string, erro
 
 	// the keys are the target dirs
 	// the values are the source files that should be copied into the target dir
-	return map[string][]string{
+	data := map[string][]string{
 		"::EFI":            {},
 		"::EFI/BOOT":       {filepath.Join(sourceDir, "BOOTX64.EFI")},
-		"::EFI/kairos":     {filepath.Join(sourceDir, kairosVersion+".efi")},
+		"::EFI/kairos":     {},
 		"::EFI/tools":      {},
 		"::loader":         {filepath.Join(sourceDir, "loader.conf")},
-		"::loader/entries": {filepath.Join(sourceDir, kairosVersion+".conf")},
+		"::loader/entries": {},
 		"::loader/keys":    {},
 		"::loader/keys/auto": {
 			filepath.Join(b.keysDirectory, "PK.der"),
@@ -444,7 +464,15 @@ func (b *BuildUKIAction) imageFiles(sourceDir string) (map[string][]string, erro
 			filepath.Join(b.keysDirectory, "PK.auth"),
 			filepath.Join(b.keysDirectory, "KEK.auth"),
 			filepath.Join(b.keysDirectory, "DB.auth")},
-	}, nil
+	}
+	// Add the kairos efi files and the loader conf files for each cmdline
+	cmdlines := utils.GetUkiCmdline()
+	for _, cmdline := range cmdlines {
+		finalEfiName := kairosVersion + strings.Replace(strings.TrimPrefix(cmdline, constants.UkiCmdline), " ", "_", -1)
+		data["::EFI/kairos"] = append(data["::EFI/kairos"], filepath.Join(sourceDir, finalEfiName+".efi"))
+		data["::loader/entries"] = append(data["::loader/entries"], filepath.Join(sourceDir, finalEfiName+".conf"))
+	}
+	return data, nil
 }
 
 func copyFilesToImg(imgFile string, filesMap map[string][]string) error {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -42,11 +42,17 @@ func GolangArchToArch(arch string) (string, error) {
 
 // GetUkiCmdline returns the cmdline to be used for the kernel.
 // The cmdline can be overridden by the user using the cmdline flag.
-func GetUkiCmdline() string {
-	cmdlineOverride := viper.GetString("cmdline")
-	if cmdlineOverride == "" {
-		return constants.UkiCmdline
+// For each cmdline passed, we generate a uki file with that cmdline
+func GetUkiCmdline() []string {
+	cmdlineOverride := viper.GetStringSlice("cmdline")
+	if len(cmdlineOverride) == 0 {
+		return []string{constants.UkiCmdline}
 	} else {
-		return constants.UkiCmdline + " " + strings.Trim(cmdlineOverride, " ")
+		var cmdline []string
+		for _, line := range cmdlineOverride {
+			cmdline = append(cmdline, fmt.Sprintf("%s %s", constants.UkiCmdline, line))
+		}
+		return cmdline
 	}
+
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -296,12 +296,18 @@ var _ = Describe("Utils", Label("utils"), func() {
 	Describe("GetUkiCmdline", Label("GetUkiCmdline"), func() {
 		It("returns the default cmdline", func() {
 			cmdline := utils.GetUkiCmdline()
-			Expect(cmdline).To(Equal(constants.UkiCmdline))
+			Expect(cmdline[0]).To(Equal(constants.UkiCmdline))
 		})
 		It("returns the default cmdline with the cmdline flag", func() {
-			viper.Set("cmdline", "key=value testkey")
+			viper.Set("cmdline", []string{"key=value testkey"})
 			cmdline := utils.GetUkiCmdline()
-			Expect(cmdline).To(Equal(constants.UkiCmdline + " key=value testkey"))
+			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
+		})
+		It("returns more than one cmdline with the cmdline flag if specified multiple values", func() {
+			viper.Set("cmdline", []string{"key=value testkey", "another=value anotherkey"})
+			cmdline := utils.GetUkiCmdline()
+			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
+			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " another=value anotherkey"))
 		})
 	})
 })


### PR DESCRIPTION
This provides the cmdline flag to be passed several times with different cmdlines  and will generate the proper efi files for each with their own cmdline so we can generate several efis and provide them in s single artifact (iso or container)

So calling enki with:

```
enki build-uki -k ${PWD}/keys/ quay.io/kairos/fedora:fedora-core-amd64-generic-v2.5.0-12-g37d0b01 -o /tmp/image/output.iso --cmdline "rd.immucore.debug" --cmdline "interactive-install"
```

will generate 2 efi files and 2 configs:

```
INFO[2024-01-26T11:34:02+01:00] running ukify for cmdline: console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 rd.immucore.debug 
INFO[2024-01-26T11:34:02+01:00] Generating: v2.5.0-12-g37d0b01_rd.immucore.debug.efi 
INFO[2024-01-26T11:34:06+01:00] creating kairos and loader conf files        
INFO[2024-01-26T11:34:06+01:00] Creating the v2.5.0-12-g37d0b01_rd.immucore.debug.conf file 
INFO[2024-01-26T11:34:06+01:00] running ukify for cmdline: console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 interactive-install 
INFO[2024-01-26T11:34:06+01:00] Generating: v2.5.0-12-g37d0b01_interactive-install.efi 
INFO[2024-01-26T11:34:10+01:00] creating kairos and loader conf files        
INFO[2024-01-26T11:34:10+01:00] Creating the v2.5.0-12-g37d0b01_interactive-install.conf file 
```

And both will appear on boot:
![image](https://github.com/kairos-io/enki/assets/1447686/bd74f37a-ea9d-4f38-ab56-ee3ea8610954)



EDIT: false alarm, it was my VM that was broken :D