### PR TITLE
Fix creating default entry when setting cmdline

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -48,7 +48,7 @@ func GetUkiCmdline() []string {
 	if len(cmdlineOverride) == 0 {
 		return []string{constants.UkiCmdline}
 	} else {
-		var cmdline []string
+		cmdline := []string{constants.UkiCmdline}
 		for _, line := range cmdlineOverride {
 			cmdline = append(cmdline, fmt.Sprintf("%s %s", constants.UkiCmdline, line))
 		}


### PR DESCRIPTION
When we add a cmdline flag, we should also create the default entry with the default cmdline in addition to the extended one