### PR TITLE
Fix cmdline for default entries

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,7 +42,8 @@ const (
 	Archx86   = "x86_64"
 	ArchArm64 = "arm64"
 
-	UkiCmdline = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 install-mode"
+	UkiCmdline        = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
+	UkiCmdlineInstall = "install-mode"
 )
 
 // GetDefaultSquashfsOptions returns the default options to use when creating a squashfs

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -46,9 +46,11 @@ func GolangArchToArch(arch string) (string, error) {
 func GetUkiCmdline() []string {
 	cmdlineOverride := viper.GetStringSlice("cmdline")
 	if len(cmdlineOverride) == 0 {
-		return []string{constants.UkiCmdline}
+		// For no extra cmdline, we default to install mode
+		return []string{constants.UkiCmdline + " " + constants.UkiCmdlineInstall}
 	} else {
-		cmdline := []string{constants.UkiCmdline}
+		// For extra cmdline, we default to install mode + extra cmdlines
+		cmdline := []string{constants.UkiCmdline + " " + constants.UkiCmdlineInstall}
 		for _, line := range cmdlineOverride {
 			cmdline = append(cmdline, fmt.Sprintf("%s %s", constants.UkiCmdline, line))
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -183,16 +183,20 @@ var _ = Describe("Utils", Label("utils"), func() {
 	Describe("GetUkiCmdline", Label("GetUkiCmdline"), func() {
 		It("returns the default cmdline", func() {
 			cmdline := utils.GetUkiCmdline()
-			Expect(cmdline[0]).To(Equal(constants.UkiCmdline))
+			Expect(cmdline[0]).To(Equal(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
 		})
-		It("returns the default cmdline with the cmdline flag", func() {
+		It("returns the default cmdline with the cmdline flag and install-mode", func() {
 			viper.Set("cmdline", []string{"key=value testkey"})
 			cmdline := utils.GetUkiCmdline()
+			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
 		})
 		It("returns more than one cmdline with the cmdline flag if specified multiple values", func() {
 			viper.Set("cmdline", []string{"key=value testkey", "another=value anotherkey"})
 			cmdline := utils.GetUkiCmdline()
+			// Should contain the default one
+			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
+			// Also the extra ones, without the install-mode
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " another=value anotherkey"))
 		})


### PR DESCRIPTION
Only add cmdline install part on the first entry, leave the other cmdlines added without that install part. Otherwise we need to check and discard that install-mode in any other entry, which makes no sense
