### PR TITLE
Add a --output-type flag to generate different output artifacts

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -15,6 +15,22 @@ go-deps:
     WORKDIR /build
     COPY go.mod go.sum . # This will make the go mod download able to be cached as long as it hasnt change
     RUN go mod download
+    SAVE ARTIFACT go.mod AS LOCAL go.mod
+    SAVE ARTIFACT go.sum AS LOCAL go.sum
+
+version:
+    FROM +go-deps
+    COPY . ./
+    RUN --no-cache echo $(git describe --always --tags --dirty) > VERSION
+    RUN --no-cache echo $(git describe --always --dirty) > COMMIT
+    ARG VERSION=$(cat VERSION)
+    ARG COMMIT=$(cat COMMIT)
+    SAVE ARTIFACT VERSION VERSION
+    SAVE ARTIFACT COMMIT COMMIT
+
+test:
+    FROM +go-deps
+    WORKDIR /build
     COPY . .
     ARG TEST_PATHS=./...
     ARG LABEL_FILTER=

--- a/Earthfile
+++ b/Earthfile
@@ -12,8 +12,9 @@ test:
     FROM golang:$GO_VERSION
     RUN apk add rsync gcc musl-dev docker jq
     WORKDIR /build
-    COPY . .
+    COPY go.mod go.sum . # This will make the go mod download able to be cached as long as it hasnt change
     RUN go mod download
+    COPY . .
     ARG TEST_PATHS=./...
     ARG LABEL_FILTER=
     ENV CGO_ENABLED=1

--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -33,12 +33,12 @@ func NewBuildUKICmd() *cobra.Command {
 			"    - tpm2-pcr-private.pem\n",
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			artifact, err := cmd.Flags().GetString("artifact")
+			artifact, err := cmd.Flags().GetString("output-type")
 			if err != nil {
 				return err
 			}
 			if artifact != string(constants.DefaultOutput) && artifact != string(constants.IsoOutput) && artifact != string(constants.ContainerOutput) {
-				return fmt.Errorf("invalid artifact type: %s", artifact)
+				return fmt.Errorf("invalid output type: %s", artifact)
 			}
 
 			return CheckRoot()
@@ -65,10 +65,10 @@ func NewBuildUKICmd() *cobra.Command {
 			}
 
 			flags := cmd.Flags()
-			outputDir, _ := flags.GetString("output")
+			outputDir, _ := flags.GetString("output-dir")
 			keysDir, _ := flags.GetString("keys")
-			artifact, _ := flags.GetString("artifact")
-			a := action.NewBuildUKIAction(cfg, imgSource, outputDir, keysDir, artifact)
+			outputType, _ := flags.GetString("output-type")
+			a := action.NewBuildUKIAction(cfg, imgSource, outputDir, keysDir, outputType)
 			err = a.Run()
 			if err != nil {
 				cfg.Logger.Errorf(err.Error())
@@ -79,11 +79,11 @@ func NewBuildUKICmd() *cobra.Command {
 		},
 	}
 
-	c.Flags().StringP("output", "o", ".", "Output dir for artifact")
+	c.Flags().StringP("output-dir", "d", ".", "Output dir for artifact")
+	c.Flags().StringP("output-type", "t", string(constants.DefaultOutput), fmt.Sprintf("Artifact output type [%s]", strings.Join(constants.OutPutTypes(), ", ")))
 	c.Flags().StringSliceP("cmdline", "c", []string{}, "Command line to ")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
 	c.MarkFlagRequired("keys")
-	c.Flags().StringP("artifact", "a", string(constants.DefaultOutput), fmt.Sprintf("Artifact type [%s]", strings.Join(constants.OutPutTypes(), ", ")))
 	return c
 }
 

--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/kairos-io/enki/pkg/action"
 	"github.com/kairos-io/enki/pkg/config"
+	"github.com/kairos-io/enki/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 // NewBuildISOCmd returns a new instance of the build-iso subcommand and appends it to
@@ -30,6 +33,14 @@ func NewBuildUKICmd() *cobra.Command {
 			"    - tpm2-pcr-private.pem\n",
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			artifact, err := cmd.Flags().GetString("artifact")
+			if err != nil {
+				return err
+			}
+			if artifact != string(constants.DefaultOutput) && artifact != string(constants.IsoOutput) && artifact != string(constants.ContainerOutput) {
+				return fmt.Errorf("invalid artifact type: %s", artifact)
+			}
+
 			return CheckRoot()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -54,9 +65,10 @@ func NewBuildUKICmd() *cobra.Command {
 			}
 
 			flags := cmd.Flags()
-			outputFile, _ := flags.GetString("output")
+			outputDir, _ := flags.GetString("output")
 			keysDir, _ := flags.GetString("keys")
-			a := action.NewBuildUKIAction(cfg, imgSource, outputFile, keysDir)
+			artifact, _ := flags.GetString("artifact")
+			a := action.NewBuildUKIAction(cfg, imgSource, outputDir, keysDir, artifact)
 			err = a.Run()
 			if err != nil {
 				cfg.Logger.Errorf(err.Error())
@@ -67,10 +79,11 @@ func NewBuildUKICmd() *cobra.Command {
 		},
 	}
 
-	c.Flags().StringP("output", "o", "output.uki.iso", "Output file name")
+	c.Flags().StringP("output", "o", ".", "Output dir for artifact")
 	c.Flags().StringSliceP("cmdline", "c", []string{}, "Command line to ")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
 	c.MarkFlagRequired("keys")
+	c.Flags().StringP("artifact", "a", string(constants.DefaultOutput), fmt.Sprintf("Artifact type [%s]", strings.Join(constants.OutPutTypes(), ", ")))
 	return c
 }
 

--- a/e2e/build_uki_test.go
+++ b/e2e/build_uki_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -17,16 +18,17 @@ var _ = Describe("build-uki", func() {
 	var enki *Enki
 
 	BeforeEach(func() {
+		kairosVersion := "v2.5.0"
 		resultDir, err = os.MkdirTemp("", "enki-build-uki-test-")
 		Expect(err).ToNot(HaveOccurred())
-		resultFile = filepath.Join(resultDir, "result.uki.iso")
+		resultFile = filepath.Join(resultDir, fmt.Sprintf("kairos_%s.iso", kairosVersion))
 
 		currentDir, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 		keysDir = filepath.Join(currentDir, "assets", "keys")
 
 		enki = NewEnki("enki-image", resultDir, keysDir)
-		image = "quay.io/kairos/fedora:38-standard-amd64-generic-v2.5.0-k3sv1.28.5-k3s1"
+		image = fmt.Sprintf("quay.io/kairos/fedora:38-core-amd64-generic-%s", kairosVersion)
 	})
 
 	AfterEach(func() {
@@ -40,7 +42,7 @@ var _ = Describe("build-uki", func() {
 		})
 
 		It("returns an error about missing deps", func() {
-			out, err := enki.Run("build-uki", image, "-o", resultFile, "-k", "assets/keys")
+			out, err := enki.Run("build-uki", image, "--output-dir", resultDir, "-k", "assets/keys", "--output-type", "iso")
 			Expect(err).To(HaveOccurred(), out)
 			Expect(out).To(Or(
 				MatchRegexp("executable file not found in \\$PATH"),
@@ -50,7 +52,7 @@ var _ = Describe("build-uki", func() {
 	})
 
 	It("successfully builds a uki iso from a container image", func() {
-		out, err := enki.Run("build-uki", image, "-o", resultFile, "-k", keysDir)
+		out, err := enki.Run("build-uki", image, "--output-dir", resultDir, "-k", keysDir, "--output-type", "iso")
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		By("building the iso")

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -33,17 +33,17 @@ type BuildUKIAction struct {
 	outputDir     string
 	keysDirectory string
 	logger        v1.Logger
-	artifact      string
+	outputType    string
 }
 
-func NewBuildUKIAction(cfg *types.BuildConfig, img *v1.ImageSource, outputDir, keysDirectory, artifact string) *BuildUKIAction {
+func NewBuildUKIAction(cfg *types.BuildConfig, img *v1.ImageSource, outputDir, keysDirectory, outputType string) *BuildUKIAction {
 	b := &BuildUKIAction{
 		logger:        cfg.Logger,
 		img:           img,
 		e:             elemental.NewElemental(&cfg.Config),
 		outputDir:     outputDir,
 		keysDirectory: keysDirectory,
-		artifact:      artifact,
+		outputType:    outputType,
 	}
 	b.logger.Debugf("BuildUKIAction: %+v", litter.Sdump(b))
 	return b
@@ -89,10 +89,10 @@ func (b *BuildUKIAction) Run() error {
 		return err
 	}
 
-	switch b.artifact {
+	switch b.outputType {
 	case string(constants.IsoOutput):
 		err = b.createISO(sourceDir)
-		b.logger.Infof("Done building %s at: %s", b.artifact, b.outputDir)
+		b.logger.Infof("Done building %s at: %s", b.outputType, b.outputDir)
 	case string(constants.ContainerOutput):
 		// First create the files
 		err = b.createArtifact(sourceDir)
@@ -117,7 +117,7 @@ func (b *BuildUKIAction) Run() error {
 		if err != nil {
 			return err
 		}
-		b.logger.Infof("Done building %s at: %s", b.artifact, b.outputDir)
+		b.logger.Infof("Done building %s at: %s", b.outputType, b.outputDir)
 	}
 
 	return err
@@ -523,7 +523,7 @@ func (b *BuildUKIAction) createContainer(sourceDir, version string) error {
 	} else {
 		b.logger.Debugf("created image: " + s)
 	}
-	b.logger.Infof("Done building %s at: %s", b.artifact, tag.String())
+	b.logger.Infof("Done building %s at: %s", b.outputType, tag.String())
 	return err
 }
 

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -100,7 +100,10 @@ func (b *BuildUKIAction) Run() error {
 			return err
 		}
 		// Then build the image
-		kairosVersion, _ := findKairosVersion(sourceDir)
+		kairosVersion, err := findKairosVersion(sourceDir)
+		if err != nil {
+			return err
+		}
 		err = b.createContainer(b.outputDir, kairosVersion)
 		if err != nil {
 			return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,16 @@ import (
 	"path/filepath"
 )
 
+type UkiOutput string
+
+const IsoOutput UkiOutput = "iso"
+const ContainerOutput UkiOutput = "container"
+const DefaultOutput UkiOutput = "artifact"
+
+func OutPutTypes() []string {
+	return []string{string(IsoOutput), string(ContainerOutput), string(DefaultOutput)}
+}
+
 const (
 	GrubDefEntry   = "Kairos"
 	EfiLabel       = "COS_GRUB"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -10,7 +10,7 @@ type UkiOutput string
 
 const IsoOutput UkiOutput = "iso"
 const ContainerOutput UkiOutput = "container"
-const DefaultOutput UkiOutput = "artifact"
+const DefaultOutput UkiOutput = "uki"
 
 func OutPutTypes() []string {
 	return []string{string(IsoOutput), string(ContainerOutput), string(DefaultOutput)}


### PR DESCRIPTION
Fixes https://github.com/kairos-io/kairos/issues/2171
Fixes https://github.com/kairos-io/kairos/issues/2202

adds a --output-type flag that allows to set the output type. Currently iso, artifact and container are supported and will generate the proper artifacts.

 - iso: Will generate an iso in the output dir
 - artifact: Will generate the UKI EFI files, configs and keys in the output dir
 - container: Will generate a container image witht he artifacts inside them (Valid for upgrade)

This changes the `--output` flag from a specific iso file to a dir (`--output-dir`), to be able to generate the output artifacts using that dir as a base. Name is now generated automatically based on the version obtained from the source.

Iso will now be kairos_VERSION.iso
Artifact/config names are kept the same as before
Container will be kairos_uki:$VERSION