### PR TITLE
Select the main efi config as default in loader.conf

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -83,6 +83,7 @@ func NewBuildUKICmd() *cobra.Command {
 	c.Flags().StringP("output-type", "t", string(constants.DefaultOutput), fmt.Sprintf("Artifact output type [%s]", strings.Join(constants.OutPutTypes(), ", ")))
 	c.Flags().StringSliceP("cmdline", "c", []string{}, "Command line to ")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
+	c.Flags().StringP("default-entry", "e", "", "Default entry selected in the boot menu.\nSupported glob wildcard patterns are \"?\", \"*\", and \"[...]\".\nIf not selected, the default entry with install-mode is selected.")
 	c.MarkFlagRequired("keys")
 	return c
 }

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -142,11 +142,16 @@ func (b *BuildUKIAction) createSystemdConf(sourceDir string) error {
 	var finalEfiConf string
 	entry := viper.GetString("default-entry")
 	if entry != "" {
-		finalEfiConf = entry
+		if !strings.HasSuffix(entry, ".conf") {
+			finalEfiConf = strings.TrimSuffix(entry, " ") + ".conf"
+		} else {
+			finalEfiConf = entry
+		}
+
 	} else {
 		// Get the generic efi file that we produce from the default cmdline
 		// This is the one name that has nothing added, just the version
-		finalEfiConf = nameFromCmdline(b.version, constants.UkiCmdline+" "+constants.UkiCmdlineInstall)
+		finalEfiConf = nameFromCmdline(b.version, constants.UkiCmdline+" "+constants.UkiCmdlineInstall) + ".conf"
 	}
 	// Set that as default selection for booting
 	data := fmt.Sprintf("default %s\ntimeout 5\nconsole-mode max\neditor no\n", finalEfiConf)

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/kairos-io/enki/pkg/constants"
+	"github.com/spf13/viper"
 	"io"
 	"math"
 	"os"
@@ -138,9 +139,15 @@ func (b *BuildUKIAction) Run() error {
 
 // createSystemdConf creates the generic conf that systemd-boot uses
 func (b *BuildUKIAction) createSystemdConf(sourceDir string) error {
-	// Get the generic efi file that we produce from the default cmdline
-	// This is the one name that has nothing added, just the version
-	finalEfiConf := nameFromCmdline(b.version, constants.UkiCmdline+" "+constants.UkiCmdlineInstall) + ".conf"
+	var finalEfiConf string
+	entry := viper.GetString("default-entry")
+	if entry != "" {
+		finalEfiConf = entry
+	} else {
+		// Get the generic efi file that we produce from the default cmdline
+		// This is the one name that has nothing added, just the version
+		finalEfiConf = nameFromCmdline(b.version, constants.UkiCmdline+" "+constants.UkiCmdlineInstall)
+	}
 	// Set that as default selection for booting
 	data := fmt.Sprintf("default %s\ntimeout 5\nconsole-mode max\neditor no\n", finalEfiConf)
 	err := os.WriteFile(filepath.Join(sourceDir, "loader.conf"), []byte(data), os.ModePerm)


### PR DESCRIPTION
This works for both media and upgrades, so it overwrites the exiting
conf and chooses the latest one

This would probably need a flag to be overridable so we allow setting
others as default if the flag is set.

Signed-off-by: Itxaka <itxaka@kairos.io>