### PR TITLE
Add a way for the user to specify key expiration and bump the default

### DIFF
--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -44,13 +44,15 @@ func NewGenkeyCmd() *cobra.Command {
 				der := filepath.Join(output, fmt.Sprintf("%s.der", keyType))
 				auth := filepath.Join(output, fmt.Sprintf("%s.auth", keyType))
 				esl := filepath.Join(output, fmt.Sprintf("%s.esl", keyType))
-				cmd := exec.Command(
-					"openssl",
+				args := []string{
 					"req", "-nodes", "-x509", "-subj", fmt.Sprintf("/CN=%s/", name),
-					"-days", viper.GetString("expiration-in-days"),
 					"-keyout", key,
 					"-out", pem,
-				)
+				}
+				if viper.GetString("expiration-in-days") != "" {
+					args = append(args, "-days", viper.GetString("expiration-in-days"))
+				}
+				cmd := exec.Command("openssl", args...)
 				out, err := cmd.CombinedOutput()
 				if err != nil {
 					l.Errorf("Error generating %s: %s", keyType, string(out))
@@ -123,6 +125,8 @@ func NewGenkeyCmd() *cobra.Command {
 	}
 	c.Flags().StringP("output", "o", "keys/", "Output directory for the keys")
 	c.Flags().StringP("expiration-in-days", "e", "365", "In how many days from today should the certificates expire")
+
+	viper.BindPFlag("expiration-in-days", c.Flags().Lookup("expiration-in-days"))
 	return c
 }
 

--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
 	"github.com/gofrs/uuid"
 	"github.com/kairos-io/enki/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"os/exec"
-	"path/filepath"
 )
 
 func NewGenkeyCmd() *cobra.Command {
@@ -46,6 +47,7 @@ func NewGenkeyCmd() *cobra.Command {
 				cmd := exec.Command(
 					"openssl",
 					"req", "-nodes", "-x509", "-subj", fmt.Sprintf("/CN=%s/", name),
+					"-days", viper.GetString("expiration-in-days"),
 					"-keyout", key,
 					"-out", pem,
 				)
@@ -73,7 +75,7 @@ func NewGenkeyCmd() *cobra.Command {
 				)
 				out, err = cmd.CombinedOutput()
 				if err != nil {
-					l.Errorf("Error generating %s: %s", keyType, string(out))
+					l.Errorf("Error generating %s: %s\n%s", keyType, string(out), err.Error())
 					return err
 				}
 				l.Infof("%s generated at %s", keyType, esl)
@@ -120,6 +122,7 @@ func NewGenkeyCmd() *cobra.Command {
 		},
 	}
 	c.Flags().StringP("output", "o", "keys/", "Output directory for the keys")
+	c.Flags().StringP("expiration-in-days", "e", "365", "In how many days from today should the certificates expire")
 	return c
 }
 

--- a/e2e/genkey_test.go
+++ b/e2e/genkey_test.go
@@ -1,0 +1,75 @@
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("genkey", func() {
+	var resultDir string
+	var err error
+	var enki *Enki
+
+	BeforeEach(func() {
+		resultDir, err = os.MkdirTemp("", "enki-genkey-test-")
+		Expect(err).ToNot(HaveOccurred())
+
+		enki = NewEnki("enki-image", resultDir)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(resultDir)
+		enki.Cleanup()
+	})
+
+	When("expiration-in-days is not specified", func() {
+		It("builds certificates with expiration in 365 days", func() {
+			out, err := enki.Run("genkey", "-o", resultDir, "mykey")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			expectExpirationIn(365, resultDir)
+		})
+	})
+
+	When("expiration-in-days is specified", func() {
+		It("builds certificates that expire after the specified days", func() {
+			out, err := enki.Run("genkey", "-o", resultDir, "-e", "1000", "mykey")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			expectExpirationIn(1000, resultDir)
+		})
+	})
+})
+
+// getDateFromString accepts a date in the form: "Feb  6 15:53:30 2025 GMT"
+// and returns the day, month and year as integers
+func getDateFromString(dateString string) (int, int, int) {
+	// Define the layout matching the format of the string
+	layout := "Jan  2 15:04:05 2006 MST"
+	dateTime, err := time.Parse(layout, dateString)
+	Expect(err).ToNot(HaveOccurred())
+
+	return dateTime.Day(), int(dateTime.Month()), dateTime.Year()
+}
+
+func expectExpirationIn(n int, resultDir string) {
+	By("checking the expiration")
+	cmd := exec.Command("openssl", "x509", "-enddate", "-noout",
+		"-in", filepath.Join(resultDir, "DB.pem"))
+	o, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+
+	dateStr := strings.TrimSpace(strings.TrimPrefix(string(o), "notAfter="))
+	certDay, certMonth, certYear := getDateFromString(dateStr)
+
+	expectedTime := time.Now().Add(time.Duration(n) * 24 * time.Hour)
+	Expect(certDay).To(Equal(expectedTime.Day()))
+	Expect(certMonth).To(Equal(int(expectedTime.Month())))
+	Expect(certYear).To(Equal(expectedTime.Year()))
+}


### PR DESCRIPTION
from 30 days to 365

Fixes https://github.com/kairos-io/kairos/issues/2218

We should have started with a test for `build-uki` earlier I'm afraid. Maybe this is too small of a change to justify stalling until there is  test but it would be nice to test it (Update: created an e2e test).