### PR TITLE
Use systemd-boot kairos artifacts and add arches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG LUET_VERSION=0.35.0
+
+FROM quay.io/luet/base:$LUET_VERSION AS luet
+
 ARG GO_VERSION=1.21-alpine3.18
 FROM golang:$GO_VERSION AS builder
 
@@ -18,6 +22,20 @@ RUN go build \
     -o /enki
 
 FROM fedora as tools-image
+COPY --from=luet /usr/bin/luet /usr/bin/luet
+ENV LUET_NOLOCK=true
+ENV TMPDIR=/tmp
+ARG TARGETARCH
+# copy both arches
+COPY luet-arm64.yaml /tmp/luet-arm64.yaml
+COPY luet-amd64.yaml /tmp/luet-amd64.yaml
+# Set the default luet config to the current build arch
+RUN mkdir -p /etc/luet/
+RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
+## Uki artifacts, will be set under the /usr/kairos directory
+## We can install both arches, as the artifacts are named differently
+RUN luet install -y system/systemd-boot
+RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot
 
 RUN dnf install -y binutils systemd-boot mtools efitools sbsigntools shim openssl systemd-ukify dosfstools xorriso rsync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir -p /etc/luet/
 RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
 ## Uki artifacts, will be set under the /usr/kairos directory
 ## We can install both arches, as the artifacts are named differently
-RUN luet install -y system/systemd-boot
+RUN luet install --config /tmp/luet-amd64.yaml -y system/systemd-boot
 RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot
 
 RUN dnf install -y binutils systemd-boot mtools efitools sbsigntools shim openssl systemd-ukify dosfstools xorriso rsync

--- a/e2e/assets/Dockerfile.enki
+++ b/e2e/assets/Dockerfile.enki
@@ -16,6 +16,6 @@ RUN mkdir -p /etc/luet/
 RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
 ## Uki artifacts, will be set under the /usr/kairos directory
 ## We can install both arches, as the artifacts are named differently
-RUN luet install -y system/systemd-boot
+RUN luet install --config /tmp/luet-amd64.yaml -y system/systemd-boot
 RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot
 RUN dnf install -y binutils systemd-boot mtools efitools sbsigntools shim openssl systemd-ukify dosfstools mtools xorriso

--- a/e2e/assets/Dockerfile.enki
+++ b/e2e/assets/Dockerfile.enki
@@ -1,4 +1,21 @@
 # A docker images suitable to run `enki build-uki` in it
-FROM fedora:39
+ARG LUET_VERSION=0.35.0
 
+FROM quay.io/luet/base:$LUET_VERSION AS luet
+
+FROM fedora:39
+COPY --from=luet /usr/bin/luet /usr/bin/luet
+ENV LUET_NOLOCK=true
+ENV TMPDIR=/tmp
+ARG TARGETARCH
+# copy both arches
+COPY luet-arm64.yaml /tmp/luet-arm64.yaml
+COPY luet-amd64.yaml /tmp/luet-amd64.yaml
+# Set the default luet config to the current build arch
+RUN mkdir -p /etc/luet/
+RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
+## Uki artifacts, will be set under the /usr/kairos directory
+## We can install both arches, as the artifacts are named differently
+RUN luet install -y system/systemd-boot
+RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot
 RUN dnf install -y binutils systemd-boot mtools efitools sbsigntools shim openssl systemd-ukify dosfstools mtools xorriso

--- a/e2e/assets/luet-amd64.yaml
+++ b/e2e/assets/luet-amd64.yaml
@@ -1,0 +1,15 @@
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos"
+    description: "kairos repository"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages"
+    reference: 20240215113356-repository.yaml

--- a/e2e/assets/luet-amd64.yaml
+++ b/e2e/assets/luet-amd64.yaml
@@ -1,1 +1,16 @@
-../../luet-amd64.yaml
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos"
+    description: "kairos repository"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages"
+    # renovate: datasource=docker depName=quay.io/kairos/packages
+    reference: 20240215113356-repository.yaml

--- a/e2e/assets/luet-amd64.yaml
+++ b/e2e/assets/luet-amd64.yaml
@@ -1,15 +1,1 @@
-general:
-  debug: false
-  spinner_charset: 9
-logging:
-  enable_emoji: false
-repositories:
-  - name: "kairos"
-    description: "kairos repository"
-    type: "docker"
-    cached: true
-    enable: true
-    priority: 2
-    urls:
-      - "quay.io/kairos/packages"
-    reference: 20240215113356-repository.yaml
+../../luet-amd64.yaml

--- a/e2e/assets/luet-arm64.yaml
+++ b/e2e/assets/luet-arm64.yaml
@@ -1,1 +1,16 @@
-../../luet-arm64.yaml
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos-arm64"
+    description: "kairos repository arm64"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages-arm64"
+    # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
+    reference: 20240215133500-repository.yaml

--- a/e2e/assets/luet-arm64.yaml
+++ b/e2e/assets/luet-arm64.yaml
@@ -1,15 +1,1 @@
-general:
-  debug: false
-  spinner_charset: 9
-logging:
-  enable_emoji: false
-repositories:
-  - name: "kairos-arm64"
-    description: "kairos repository arm64"
-    type: "docker"
-    cached: true
-    enable: true
-    priority: 2
-    urls:
-      - "quay.io/kairos/packages-arm64"
-    reference: 20240215133500-repository.yaml
+../../luet-arm64.yaml

--- a/e2e/assets/luet-arm64.yaml
+++ b/e2e/assets/luet-arm64.yaml
@@ -1,0 +1,15 @@
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos-arm64"
+    description: "kairos repository arm64"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages-arm64"
+    reference: 20240215133500-repository.yaml

--- a/luet-amd64.yaml
+++ b/luet-amd64.yaml
@@ -1,0 +1,15 @@
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos"
+    description: "kairos repository"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages"
+    reference: 20240215113356-repository.yaml

--- a/luet-amd64.yaml
+++ b/luet-amd64.yaml
@@ -12,4 +12,5 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
+    # renovate: datasource=docker depName=quay.io/kairos/packages
     reference: 20240215113356-repository.yaml

--- a/luet-arm64.yaml
+++ b/luet-arm64.yaml
@@ -12,4 +12,5 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages-arm64"
+    # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
     reference: 20240215133500-repository.yaml

--- a/luet-arm64.yaml
+++ b/luet-arm64.yaml
@@ -1,0 +1,15 @@
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos-arm64"
+    description: "kairos repository arm64"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages-arm64"
+    reference: 20240215133500-repository.yaml

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -433,10 +433,10 @@ func (b *BuildUKIAction) ukify(sourceDir, cmdline string) error {
 func (b *BuildUKIAction) sbSign(sourceDir string) error {
 	var systemdBoot string
 	var outputEfi string
-	if b.arch == "x86_64" || b.arch == "amd64" {
+	if utils.IsAmd64(b.arch) {
 		systemdBoot = constants.UkiSystemdBootx86
 		outputEfi = constants.EfiFallbackNamex86
-	} else if b.arch == "aarch64" || b.arch == "arm64" {
+	} else if utils.IsArm64(b.arch) {
 		systemdBoot = constants.UkiSystemdBootArm
 		outputEfi = constants.EfiFallbackNameArm
 	} else {
@@ -670,9 +670,9 @@ func (b *BuildUKIAction) removeUkiFiles() error {
 }
 
 func (b *BuildUKIAction) getEfiStub() (string, error) {
-	if b.arch == "x86_64" || b.arch == "amd64" {
+	if utils.IsAmd64(b.arch) {
 		return constants.UkiSystemdBootStubx86, nil
-	} else if b.arch == "aarch64" || b.arch == "arm64" {
+	} else if utils.IsArm64(b.arch) {
 		return constants.UkiSystemdBootStubArm, nil
 	} else {
 		return "", nil
@@ -680,12 +680,12 @@ func (b *BuildUKIAction) getEfiStub() (string, error) {
 }
 
 func (b *BuildUKIAction) getEfiNeededFiles() ([]string, error) {
-	if b.arch == "x86_64" || b.arch == "amd64" {
+	if utils.IsAmd64(b.arch) {
 		return []string{
 			constants.UkiSystemdBootStubx86,
 			constants.UkiSystemdBootx86,
 		}, nil
-	} else if b.arch == "aarch64" || b.arch == "arm64" {
+	} else if utils.IsArm64(b.arch) {
 		return []string{
 			constants.UkiSystemdBootStubArm,
 			constants.UkiSystemdBootArm,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,8 +52,15 @@ const (
 	Archx86   = "x86_64"
 	ArchArm64 = "arm64"
 
-	UkiCmdline        = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
-	UkiCmdlineInstall = "install-mode"
+	UkiCmdline            = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
+	UkiCmdlineInstall     = "install-mode"
+	UkiSystemdBootx86     = "/usr/kairos/systemd-bootx64.efi"
+	UkiSystemdBootStubx86 = "/usr/kairos/linuxx64.efi.stub"
+	UkiSystemdBootArm     = "/usr/kairos/systemd-bootaa64.efi"
+	UkiSystemdBootStubArm = "/usr/kairos/linuxaa64.efi.stub"
+
+	EfiFallbackNamex86 = "BOOTX64.EFI"
+	EfiFallbackNameArm = "BOOTAA64.EFI"
 )
 
 // GetDefaultSquashfsOptions returns the default options to use when creating a squashfs

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,9 +48,10 @@ const (
 	NoWriteDirPerm = 0555 | os.ModeDir
 	TempDirPerm    = os.ModePerm | os.ModeSticky | os.ModeDir
 
-	ArchAmd64 = "amd64"
-	Archx86   = "x86_64"
-	ArchArm64 = "arm64"
+	ArchAmd64   = "amd64"
+	Archx86     = "x86_64"
+	ArchArm64   = "arm64"
+	Archaarch64 = "aarch64"
 
 	UkiCmdline            = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
 	UkiCmdlineInstall     = "install-mode"

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -219,3 +219,11 @@ func imageFromTar(imagename, architecture, OS string, opener func() (io.ReadClos
 
 	return newRef, img, nil
 }
+
+func IsAmd64(arch string) bool {
+	return arch == constants.ArchAmd64 || arch == constants.Archx86
+}
+
+func IsArm64(arch string) bool {
+	return arch == constants.ArchArm64 || arch == constants.Archaarch64
+}

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,14 @@
   "timezone": "Europe/Brussels",
   "packageRules": [
     {
+      "groupName": "repositories",
+      "matchPackagePatterns": ["^quay.io/kairos/packages*"]
+    },
+    {
+      "matchPackagePatterns": ["^quay.io/kairos/packages*"],
+      "versioning": "regex:^(?<major>\\d{14})(?<compatibility>-repository\\.yaml)"
+    },
+    {
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }
@@ -24,6 +32,14 @@
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG\\s+.+_VERSION=\"?(?<currentValue>.*?)\"?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "^luet-*.yaml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)?\\s+reference:\\s(?<currentValue>.*?)\\s"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Uses the artifacts provided by our luet packages in a given location. As this artifacts are decoupled from the other systemd components, we can have those in the latests varsions and take advantage of the most recent improvements.

Also adds arches into enki build-uki so it picks the proper artifacts depending on the arch enki is running from, so building in an arm device will uses systemd-boot arm artifacts

Moves all names into constants