### PR TITLE
Add extra-cmdline and extend-cmdline

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -129,10 +129,13 @@ func NewBuildUKICmd() *cobra.Command {
 	c.Flags().StringP("overlay-rootfs", "o", "", "Dir with files to be applied to the system rootfs.\nAll the files under this dir will be copied into the rootfs of the uki respecting the directory structure under the dir.")
 	c.Flags().StringP("overlay-iso", "i", "", "Dir with files to be copied to the Iso rootfs.")
 	c.Flags().StringP("boot-branding", "", "Kairos", "Boot title branding")
-	c.Flags().StringSliceP("cmdline", "c", []string{}, "Command line to ")
+	c.Flags().StringSliceP("extra-cmdline", "c", []string{}, "Add extra efi files with this cmdline. This creates a base efi with the default cmdline and extra efi files with the default+provided cmdline.")
+	c.Flags().StringP("extend-cmdline", "x", "", "Extend the default cmdline with this parameters. This creates a single efi entry with the default+provided cmdline.")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
 	c.Flags().StringP("default-entry", "e", "", "Default entry selected in the boot menu.\nSupported glob wildcard patterns are \"?\", \"*\", and \"[...]\".\nIf not selected, the default entry with install-mode is selected.")
 	c.MarkFlagRequired("keys")
+	// Mark some flags as mutually exclusive
+	c.MarkFlagsMutuallyExclusive([]string{"extra-cmdline", "extend-cmdline"}...)
 	return c
 }
 

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -56,8 +56,17 @@ func GolangArchToArch(arch string) (string, error) {
 // GetUkiCmdline returns the cmdline to be used for the kernel.
 // The cmdline can be overridden by the user using the cmdline flag.
 // For each cmdline passed, we generate a uki file with that cmdline
+// extend-cmdline will just extend the default cmdline so we only create one efi file
+// extra-cmdline will create a new efi file for each cmdline passed
 func GetUkiCmdline() []string {
-	cmdlineOverride := viper.GetStringSlice("cmdline")
+	// Extend only
+	cmdlineExtend := viper.GetString("extend-cmdline")
+	if cmdlineExtend != "" {
+		return []string{constants.UkiCmdline + " " + cmdlineExtend}
+	}
+
+	// extra
+	cmdlineOverride := viper.GetStringSlice("extra-cmdline")
 	if len(cmdlineOverride) == 0 {
 		// For no extra cmdline, we default to install mode
 		return []string{constants.UkiCmdline + " " + constants.UkiCmdlineInstall}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -62,7 +62,7 @@ func GetUkiCmdline() []string {
 	// Extend only
 	cmdlineExtend := viper.GetString("extend-cmdline")
 	if cmdlineExtend != "" {
-		return []string{constants.UkiCmdline + " " + cmdlineExtend}
+		return []string{constants.UkiCmdline + " " + constants.UkiCmdlineInstall + " " + cmdlineExtend}
 	}
 
 	// extra

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -186,19 +186,24 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(cmdline[0]).To(Equal(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
 		})
 		It("returns the default cmdline with the cmdline flag and install-mode", func() {
-			viper.Set("cmdline", []string{"key=value testkey"})
+			viper.Set("extra-cmdline", []string{"key=value testkey"})
 			cmdline := utils.GetUkiCmdline()
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
 		})
 		It("returns more than one cmdline with the cmdline flag if specified multiple values", func() {
-			viper.Set("cmdline", []string{"key=value testkey", "another=value anotherkey"})
+			viper.Set("extra-cmdline", []string{"key=value testkey", "another=value anotherkey"})
 			cmdline := utils.GetUkiCmdline()
 			// Should contain the default one
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " " + constants.UkiCmdlineInstall))
 			// Also the extra ones, without the install-mode
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " key=value testkey"))
 			Expect(cmdline).To(ContainElements(constants.UkiCmdline + " another=value anotherkey"))
+		})
+		It("expands the default cmdline if extended-cmdline is used", func() {
+			viper.Set("extend-cmdline", "key=value testkey")
+			cmdline := utils.GetUkiCmdline()
+			Expect(cmdline).To(ContainElement(constants.UkiCmdline + " " + constants.UkiCmdlineInstall + " key=value testkey"))
 		})
 	})
 })


### PR DESCRIPTION
extra-cmdline will generate extra efi files with the give cmdline + default
extend-cmdline will generate just one efi file with the given cmdline+default



calling it with extend `--debug build-uki -k ${PWD}/keys/ -d /tmp/kaka/ --output-type iso ttl.sh/ubuntuslm  -x "first"` produces:

```
[]string{
  "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 first",
}
```

calling it with extra `--debug build-uki -k ${PWD}/keys/ -d /tmp/kaka/ --output-type iso ttl.sh/ubuntuslm  -c "first" -c "second"` produces:

```
[]string{
  "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 install-mode",
  "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 first",
  "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 second",
}
```