### PR TITLE
check if generated efi file has size bigger than limit

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -135,6 +135,7 @@ func NewBuildUKICmd() *cobra.Command {
 	c.Flags().StringP("extend-cmdline", "x", "", "Extend the default cmdline with this parameters. This creates a single efi entry with the default+provided cmdline.")
 	c.Flags().StringP("keys", "k", "", "Directory with the signing keys")
 	c.Flags().StringP("default-entry", "e", "", "Default entry selected in the boot menu.\nSupported glob wildcard patterns are \"?\", \"*\", and \"[...]\".\nIf not selected, the default entry with install-mode is selected.")
+	c.Flags().Int64P("efi-size-warn", "", 1024, "EFI file size warning threshold in megabytes. Default is 1024.")
 	c.MarkFlagRequired("keys")
 	// Mark some flags as mutually exclusive
 	c.MarkFlagsMutuallyExclusive([]string{"extra-cmdline", "extend-cmdline"}...)

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -399,6 +399,8 @@ func (b *BuildUKIAction) ukify(sourceDir, artifactsTempDir, cmdline string) erro
 		return fmt.Errorf("running ukify: %w\n%s", err, string(out))
 	}
 
+	b.logger.Debugf("ukify output: %s", string(out))
+
 	// check size of the efi file
 	fi, err := os.Stat(finalEfiName)
 	if err != nil {
@@ -408,7 +410,6 @@ func (b *BuildUKIAction) ukify(sourceDir, artifactsTempDir, cmdline string) erro
 		b.logger.Warnf("EFI file %s is larger than %d bytes", finalEfiName, sizeLimit)
 	}
 
-	b.logger.Debugf("ukify output: %s", string(out))
 	return nil
 }
 

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -406,7 +406,7 @@ func (b *BuildUKIAction) ukify(sourceDir, artifactsTempDir, cmdline string) erro
 	if err != nil {
 		return fmt.Errorf("getting file info for %s: %w", finalEfiName, err)
 	}
-	if sizeLimit := viper.GetInt64("efi-size-warn"); fi.Size() > sizeLimit {
+	if sizeLimit := viper.GetInt64("efi-size-warn"); fi.Size() > sizeLimit*1024 {
 		b.logger.Warnf("EFI file %s is larger than %d bytes", finalEfiName, sizeLimit)
 	}
 

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -398,6 +398,16 @@ func (b *BuildUKIAction) ukify(sourceDir, artifactsTempDir, cmdline string) erro
 	if err != nil {
 		return fmt.Errorf("running ukify: %w\n%s", err, string(out))
 	}
+
+	// check size of the efi file
+	fi, err := os.Stat(finalEfiName)
+	if err != nil {
+		return fmt.Errorf("getting file info for %s: %w", finalEfiName, err)
+	}
+	if sizeLimit := viper.GetInt64("efi-size-warn"); fi.Size() > sizeLimit {
+		b.logger.Warnf("EFI file %s is larger than %d bytes", finalEfiName, sizeLimit)
+	}
+
 	b.logger.Debugf("ukify output: %s", string(out))
 	return nil
 }

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -406,7 +406,7 @@ func (b *BuildUKIAction) ukify(sourceDir, artifactsTempDir, cmdline string) erro
 	if err != nil {
 		return fmt.Errorf("getting file info for %s: %w", finalEfiName, err)
 	}
-	if sizeLimit := viper.GetInt64("efi-size-warn"); fi.Size() > sizeLimit*1024 {
+	if sizeLimit := viper.GetInt64("efi-size-warn"); fi.Size() > sizeLimit*1024*1024 {
 		b.logger.Warnf("EFI file %s is larger than %d bytes", finalEfiName, sizeLimit)
 	}
 


### PR DESCRIPTION
Solve https://github.com/kairos-io/kairos/issues/2347

Added a check for generated efi file size and provides an arg to configure to the size limit. If EFI file size is bigger than the limit, we should throw a warning.