### PR TITLE
Add microsoft certificate to the enki image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENTRYPOINT ["/enki"]
 FROM gcr.io/kaniko-project/executor:latest
 
 COPY --from=builder /enki /enki
+COPY microsoft /microsoft
 
 ENTRYPOINT ["/enki"]
 


### PR DESCRIPTION
so that they are found when running the "genkey" command We also need to copy them to the osbuilder-tools image