### PR TITLE
Mark the secure boot enroll to if-safe

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -86,6 +86,20 @@ func NewBuildUKICmd() *cobra.Command {
 				}
 			}
 
+			// Check if the keys directory exists
+			keysDir, _ := cmd.Flags().GetString("keys")
+			_, err = os.Stat(keysDir)
+			if err != nil {
+				return fmt.Errorf("keys directory does not exist: %s", keysDir)
+			}
+			// Check if the keys directory contains the required files
+			requiredFiles := []string{"db.crt", "db.der", "db.key", "db.auth", "KEK.der", "KEK.auth", "PK.der", "PK.auth", "tpm2-pcr-private.pem"}
+			for _, file := range requiredFiles {
+				_, err = os.Stat(filepath.Join(keysDir, file))
+				if err != nil {
+					return fmt.Errorf("keys directory does not contain required file: %s", file)
+				}
+			}
 			return CheckRoot()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -93,7 +93,7 @@ func NewBuildUKICmd() *cobra.Command {
 				return fmt.Errorf("keys directory does not exist: %s", keysDir)
 			}
 			// Check if the keys directory contains the required files
-			requiredFiles := []string{"db.crt", "db.der", "db.key", "db.auth", "KEK.der", "KEK.auth", "PK.der", "PK.auth", "tpm2-pcr-private.pem"}
+			requiredFiles := []string{"db.der", "db.key", "db.auth", "KEK.der", "KEK.auth", "PK.der", "PK.auth", "tpm2-pcr-private.pem"}
 			for _, file := range requiredFiles {
 				_, err = os.Stat(filepath.Join(keysDir, file))
 				if err != nil {

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -183,7 +183,7 @@ func (b *BuildUKIAction) createSystemdConf(sourceDir string) error {
 		finalEfiConf = nameFromCmdline(constants.UkiCmdline+" "+constants.UkiCmdlineInstall) + ".conf"
 	}
 	// Set that as default selection for booting
-	data := fmt.Sprintf("default %s\ntimeout 5\nconsole-mode max\neditor no\nsecure-boot-enroll manual\n", finalEfiConf)
+	data := fmt.Sprintf("default %s\ntimeout 5\nconsole-mode max\neditor no\nsecure-boot-enroll if-safe\n", finalEfiConf)
 	err := os.WriteFile(filepath.Join(sourceDir, "loader.conf"), []byte(data), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("creating the loader.conf file: %s", err)


### PR DESCRIPTION
So it autoenrolls in safe environments (VMs) should make it easier for testing as enrolling the keys in VMs is a safe operation.

Also adds a check for the existance of the needed keys BEFORE we start the whole process.

Signed-off-by: Itxaka <itxaka@kairos.io>