### PR TITLE
Fix signing

### DIFF
--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -146,7 +146,15 @@ func init() {
 
 func generateAuthKeys(guid efiutil.EFIGUID, keyPath, keyType, customDerCertDir string) error {
 	// Prepare all the keys we need
-	key, err := fs.ReadFile(filepath.Join(keyPath, keyType+".key"))
+	var err error
+	var key []byte
+
+	switch keyType {
+	case "PK", "KEK": // PK signs itself and KEK
+		key, err = fs.ReadFile(filepath.Join(keyPath, "PK.key"))
+	case "db": // KEK signs db
+		key, err = fs.ReadFile(filepath.Join(keyPath, "KEK.key"))
+	}
 	if err != nil {
 		return fmt.Errorf("reading the key file %w", err)
 	}

--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -73,7 +73,7 @@ func NewGenkeyCmd() *cobra.Command {
 				der := filepath.Join(output, fmt.Sprintf("%s.der", keyType))
 
 				args := []string{
-					"req", "-nodes", "-x509", "-subj", fmt.Sprintf("/CN=%s/", name),
+					"req", "-nodes", "-x509", "-subj", fmt.Sprintf("/CN=%s-%s/", name, keyType),
 					"-keyout", key,
 					"-out", pem,
 				}


### PR DESCRIPTION
While working on [this ticket](https://github.com/kairos-io/kairos/issues/2429) I (re)discovered that we broke the chain of signatures when we refactored the code to use go-uefi and sbctl.

Although this should be the right way to sign the various databases, I couldn't find a case where this chain of trust is actually checked, neither in qemu or real hardware (asus pn64). See the linked ticket for more.

In any case, let's get this fixed in case some firmware cares about it.