### PR TITLE
Don't set immucore to debug mode by default

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,7 +53,7 @@ const (
 	ArchArm64   = "arm64"
 	Archaarch64 = "aarch64"
 
-	UkiCmdline            = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
+	UkiCmdline            = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0"
 	UkiCmdlineInstall     = "install-mode"
 	UkiSystemdBootx86     = "/usr/kairos/systemd-bootx64.efi"
 	UkiSystemdBootStubx86 = "/usr/kairos/linuxx64.efi.stub"


### PR DESCRIPTION
because it could expose sensitive config information in log files

Fixes https://github.com/kairos-io/kairos/issues/2575