### PR TITLE
Allow customizing artifact name for build-uki command

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -23,7 +23,7 @@ func NewBuildUKICmd() *cobra.Command {
 		Long: "Build a UKI artifact from a container image\n\n" +
 			"SourceImage - should be provided as uri in following format <sourceType>:<sourceName>\n" +
 			"    * <sourceType> - might be [\"dir\", \"file\", \"oci\", \"docker\"], as default is \"docker\"\n" +
-			"    * <sourceName> - is path to file or directory, image name with tag version" +
+			"    * <sourceName> - is path to file or directory, image name with tag version\n" +
 			"The following files are expected inside the keys directory:\n" +
 			"    - DB.crt\n" +
 			"    - DB.der\n" +

--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -138,6 +138,7 @@ func NewBuildUKICmd() *cobra.Command {
 		},
 	}
 
+	c.Flags().StringP("name", "n", "", "Basename of the generated artifact (ignored for uki output type)")
 	c.Flags().StringP("output-dir", "d", ".", "Output dir for artifact")
 	c.Flags().StringP("output-type", "t", string(constants.DefaultOutput), fmt.Sprintf("Artifact output type [%s]", strings.Join(constants.OutPutTypes(), ", ")))
 	c.Flags().StringP("overlay-rootfs", "o", "", "Dir with files to be applied to the system rootfs.\nAll the files under this dir will be copied into the rootfs of the uki respecting the directory structure under the dir.")

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -34,6 +34,7 @@ type BuildUKIAction struct {
 	outputType    string
 	version       string
 	arch          string
+	name          string
 }
 
 func NewBuildUKIAction(cfg *types.BuildConfig, img *v1.ImageSource, outputDir, keysDirectory, outputType string) *BuildUKIAction {
@@ -45,6 +46,7 @@ func NewBuildUKIAction(cfg *types.BuildConfig, img *v1.ImageSource, outputDir, k
 		keysDirectory: keysDirectory,
 		outputType:    outputType,
 		arch:          cfg.Arch,
+		name:          cfg.Name,
 	}
 	b.logger.Debugf("BuildUKIAction: %+v", litter.Sdump(b))
 	return b
@@ -532,6 +534,9 @@ func (b *BuildUKIAction) createISO(sourceDir string) error {
 	}
 
 	isoName := fmt.Sprintf("kairos_%s.iso", b.version)
+	if b.name != "" {
+		isoName = fmt.Sprintf("%s.iso", b.name)
+	}
 
 	b.logger.Info("Creating the iso files with xorriso")
 	cmd := exec.Command("xorriso", "-as", "mkisofs", "-V", "UKI_ISO_INSTALL", "-isohybrid-gpt-basdat",
@@ -561,7 +566,11 @@ func (b *BuildUKIAction) createContainer(sourceDir, version string) error {
 	arch := "amd64"
 	os := "linux"
 	// Build imageTar from normal tar
-	err = utils.CreateTar(b.logger, temp.Name(), finalImage, fmt.Sprintf("kairos_uki:%s", version), arch, os)
+	tarName := fmt.Sprintf("kairos_uki_%s.tar", version)
+	if b.name != "" {
+		tarName = fmt.Sprintf("%s.tar", b.name)
+	}
+	err = utils.CreateTar(b.logger, temp.Name(), finalImage, tarName, arch, os)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `build-iso` command accepts a `--name` flag to specify the basename
of the generated iso file, while the `build-uki` command uses the value
of `KAIROS_RELEASE` from the `/etc/os-release` file.
This commit introduces a `--name` flag for the `build-uki` command to
allow specifying the basename of the generated .iso or .tar file.
When the output type is `uki` the `--name` flag is ignored, because the
uki output type write the uki filesystem into the output folder.