### PR TITLE
Make cpio files reproducible

### DIFF
--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -322,8 +322,11 @@ func (b *BuildUKIAction) createInitramfs(sourceDir, artifactsTempDir string) err
 			return fmt.Errorf("getting record of %q failed: %w", filePath, err)
 		}
 
-		rec.Name = strings.TrimPrefix(rec.Name, sourceDir)
-		if err := rw.WriteRecord(rec); err != nil {
+		if rec.Name != strings.TrimPrefix(rec.Name, sourceDir) {
+			rec.Name = strings.TrimPrefix(rec.Name, sourceDir)
+		}
+
+		if err := rw.WriteRecord(cpio.MakeReproducible(rec)); err != nil {
 			return fmt.Errorf("writing record %q failed: %w", filePath, err)
 		}
 


### PR DESCRIPTION
So when we input the same files, we get the same output always.

This is done on the cpio record copying by mostly setting all fields to 0

Also only change names of the record if needed

This allows us to reproduce measurements for a given point in time + private key exactly.