### PR TITLE
Fix luet arches not installing proper packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,7 @@ COPY luet-amd64.yaml /tmp/luet-amd64.yaml
 RUN mkdir -p /etc/luet/
 RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
 ## Uki artifacts, will be set under the /usr/kairos directory
-## We can install both arches, as the artifacts are named differently
-RUN luet install --config /tmp/luet-amd64.yaml -y system/systemd-boot
-RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot
+RUN luet install -y system/systemd-boot
 
 RUN dnf install -y binutils mtools efitools shim openssl dosfstools xorriso rsync
 


### PR DESCRIPTION
Seems like we cannot install the same package even if its from a different arch. This is what we do on osbuilder so it makes sense to do the same here, each arch brings its own arch artifacts


Should fix the bump of repositories like this one https://github.com/kairos-io/enki/pull/130