### PR TITLE
Add support for custom spash image

### DIFF
--- a/cmd/build-uki.go
+++ b/cmd/build-uki.go
@@ -153,6 +153,7 @@ func NewBuildUKICmd() *cobra.Command {
 	c.Flags().StringP("default-entry", "e", "", "Default entry selected in the boot menu.\nSupported glob wildcard patterns are \"?\", \"*\", and \"[...]\".\nIf not selected, the default entry with install-mode is selected.")
 	c.Flags().Int64P("efi-size-warn", "", 1024, "EFI file size warning threshold in megabytes. Default is 1024.")
 	c.Flags().String("secure-boot-enroll", "if-safe", "The value of secure-boot-enroll option of systemd-boot. Possible values: off|manual|if-safe|force. Minimum systemd version: 253. Docs: https://manpages.debian.org/experimental/systemd-boot/loader.conf.5.en.html. !! Danger: this feature might soft-brick your device if used improperly !!")
+	c.Flags().StringP("splash", "", "", "Path to the custom logo splash BMP file.")
 
 	c.MarkFlagRequired("keys")
 	// Mark some flags as mutually exclusive

--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -158,6 +158,7 @@ func (b *BuildUKIAction) Run() error {
 			SBCert:        filepath.Join(b.keysDirectory, "db.pem"),
 			SdBootPath:    systemdBoot,
 			OutSdBootPath: outputSystemdBootEfi,
+			Splash:        viper.GetString("splash"),
 		}
 
 		if err := os.Chdir(sourceDir); err != nil {


### PR DESCRIPTION
Adds a flag for setting a custom bmp.

I have tested this on x86_64 using a 566x167 pixel BMP file on a Minisforum MS-01 computer and 1080p monitor. 

This is related to https://github.com/kairos-io/go-ukify/pull/22  and will close https://github.com/kairos-io/kairos/issues/2899 with the addition of documentation.