### PR TITLE
Refactor enki build-uki command

### DIFF
--- a/pkg/action/build-uki.go
+++ b/pkg/action/build-uki.go
@@ -45,7 +45,55 @@ type BuildUKIAction struct {
 	name                   string
 }
 
-func NewBuildUKIAction(cfg *types.BuildConfig, img *v1.ImageSource) *BuildUKIAction {
+type BuildUKIActionOpt func(a *BuildUKIAction)
+
+func WithLogger(logger sdkTypes.KairosLogger) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.logger = logger }
+}
+func WithImage(img *v1.ImageSource) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.img = img }
+}
+func WithOutputDir(dir string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.outputDir = dir }
+}
+func WithOutputType(outType string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.outputType = outType }
+}
+func WithKeysDir(dir string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.keysDirectory = dir }
+}
+func WithArch(arch string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.arch = arch }
+}
+func WithName(name string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.name = name }
+}
+func WithOverlayRootFS(o string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.overlayRootFS = o }
+}
+func WithOverlayISO(o string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.overlayISO = o }
+}
+func WithDefaultEntry(e string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.defaultEntry = e }
+}
+func WithSplash(s string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.splash = s }
+}
+func WithVersion(v string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.version = v }
+}
+func WithSecureBootEnroll(s string) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.secureBootEnroll = s }
+}
+func WithIncludeVersionInConfig(s bool) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.includeVersionInConfig = s }
+}
+func WithIncludeCmdLineInConfig(s bool) func(a *BuildUKIAction) {
+	return func(a *BuildUKIAction) { a.includeCmdLineInConfig = s }
+}
+
+func NewBuildUKIAction(cfg *types.BuildConfig, opts ...BuildUKIActionOpt) *BuildUKIAction {
 	b := &BuildUKIAction{
 		logger:        cfg.Logger,
 		img:           img,

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -18,9 +18,13 @@ type LiveISO struct {
 
 // BuildConfig represents the config we need for building isos, raw images, artifacts
 type BuildConfig struct {
-	Date   bool   `yaml:"date,omitempty" mapstructure:"date"`
-	Name   string `yaml:"name,omitempty" mapstructure:"name"`
-	OutDir string `yaml:"output,omitempty" mapstructure:"output"`
+	Date          bool   `yaml:"date,omitempty" mapstructure:"date"`
+	Name          string `yaml:"name,omitempty" mapstructure:"name"`
+	OutDir        string `yaml:"output,omitempty" mapstructure:"output"`
+	OutputType    string `yaml:"output_type,omitempty" mapstructure:"output_type"`
+	KeysDir       string `yaml:"keys_dir,omitempty" mapstructure:"keys_dir"`
+	OverlayRootFS string `yaml:"overlay_rootfs,omitempty" mapstructure:"overlay_rootfs"`
+	OverlayISO    string `yaml:"overlay_iso,omitempty" mapstructure:"overlay_iso"`
 
 	// 'inline' and 'squash' labels ensure config fields
 	// are embedded from a yaml and map PoV

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -18,13 +18,7 @@ type LiveISO struct {
 
 // BuildConfig represents the config we need for building isos, raw images, artifacts
 type BuildConfig struct {
-	Date          bool   `yaml:"date,omitempty" mapstructure:"date"`
-	Name          string `yaml:"name,omitempty" mapstructure:"name"`
-	OutDir        string `yaml:"output,omitempty" mapstructure:"output"`
-	OutputType    string `yaml:"output_type,omitempty" mapstructure:"output_type"`
-	KeysDir       string `yaml:"keys_dir,omitempty" mapstructure:"keys_dir"`
-	OverlayRootFS string `yaml:"overlay_rootfs,omitempty" mapstructure:"overlay_rootfs"`
-	OverlayISO    string `yaml:"overlay_iso,omitempty" mapstructure:"overlay_iso"`
+	Date bool `yaml:"date,omitempty" mapstructure:"date"`
 
 	// 'inline' and 'squash' labels ensure config fields
 	// are embedded from a yaml and map PoV


### PR DESCRIPTION
so that it can be used as a library from Auroraboot as part of https://github.com/kairos-io/kairos/issues/1633

The following anti-patterns make it very hard to re-use the enki functions:

- viper is used as a global store, randomly accessing everything from anywhere
- we pass around too many "configs": the BuildConfig, the embedded kairos-agent config, the BuildUKIAction (which is essentially yet another config),

It's nearly impossible to construct the proper input for any function because we don't know what part of the configs available, is actually needed and used.

This is a first refactoring that should at least let the caller use the BuildUKIAction without needing to populate a global "viper" object.